### PR TITLE
Feat/Chapter4 도메인 구조에서 엔티티 추가

### DIFF
--- a/src/main/java/com/spring_b/domain/common/BaseEntity.java
+++ b/src/main/java/com/spring_b/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.spring_b.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/spring_b/domain/food/enums/FoodCategory.java
+++ b/src/main/java/com/spring_b/domain/food/enums/FoodCategory.java
@@ -1,0 +1,22 @@
+package com.spring_b.domain.food.enums;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FoodCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+
+}
+

--- a/src/main/java/com/spring_b/domain/mapping/MemberAgree.java
+++ b/src/main/java/com/spring_b/domain/mapping/MemberAgree.java
@@ -1,0 +1,31 @@
+package com.spring_b.domain.mapping;
+
+import com.spring_b.domain.common.BaseEntity;
+import com.spring_b.domain.member.entity.Member;
+import com.spring_b.domain.member.entity.Terms;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberAgree extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "terms_id")
+    private Terms terms;
+
+
+}

--- a/src/main/java/com/spring_b/domain/mapping/MemberMission.java
+++ b/src/main/java/com/spring_b/domain/mapping/MemberMission.java
@@ -1,0 +1,33 @@
+package com.spring_b.domain.mapping;
+
+import com.spring_b.domain.common.BaseEntity;
+import com.spring_b.domain.member.entity.Member;
+import com.spring_b.domain.mission.entity.Mission;
+import com.spring_b.domain.mission.enums.MissionStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberMission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private MissionStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id")
+    private Mission mission;
+}

--- a/src/main/java/com/spring_b/domain/mapping/MemberPrefer.java
+++ b/src/main/java/com/spring_b/domain/mapping/MemberPrefer.java
@@ -1,0 +1,30 @@
+package com.spring_b.domain.mapping;
+
+import com.spring_b.domain.common.BaseEntity;
+import com.spring_b.domain.food.enums.FoodCategory;
+import com.spring_b.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberPrefer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private FoodCategory foodCategory;
+
+}

--- a/src/main/java/com/spring_b/domain/member/entity/Member.java
+++ b/src/main/java/com/spring_b/domain/member/entity/Member.java
@@ -1,0 +1,81 @@
+package com.spring_b.domain.member.entity;
+
+import com.spring_b.domain.common.BaseEntity;
+import com.spring_b.domain.mapping.MemberAgree;
+import com.spring_b.domain.mapping.MemberMission;
+import com.spring_b.domain.mapping.MemberPrefer;
+import com.spring_b.domain.member.enums.Gender;
+import com.spring_b.domain.member.enums.MemberStatus;
+import com.spring_b.domain.member.enums.Role;
+import com.spring_b.domain.member.enums.SocialType;
+import com.spring_b.domain.mission.enums.MissionStatus;
+import com.spring_b.domain.review.entity.Review;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DynamicUpdate
+@DynamicInsert
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String address;
+
+    private String specAddress;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(15) DEFAULT 'ACTIVE'")
+    private MemberStatus memberstatus;
+
+    @Enumerated(EnumType.STRING)
+    private MissionStatus missionstatus;
+
+    private LocalDate inactiveDate;
+
+    @Column(nullable = false, length = 50)
+    private String email;
+
+    @Column(nullable=false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @ColumnDefault("0")
+    private Integer point;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberAgree> memberAgreeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberPrefer> memberPreferList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Review> reviewList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberMission> memberMissionList = new ArrayList<>();
+
+}

--- a/src/main/java/com/spring_b/domain/member/entity/Terms.java
+++ b/src/main/java/com/spring_b/domain/member/entity/Terms.java
@@ -1,0 +1,29 @@
+package com.spring_b.domain.member.entity;
+
+import com.spring_b.domain.mapping.MemberAgree;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Terms {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String body;
+
+    private Boolean optional;
+
+    @OneToMany(mappedBy = "terms", cascade = CascadeType.ALL)
+    private List<MemberAgree> memberAgreeList = new ArrayList<>();
+}

--- a/src/main/java/com/spring_b/domain/member/enums/Gender.java
+++ b/src/main/java/com/spring_b/domain/member/enums/Gender.java
@@ -1,0 +1,5 @@
+package com.spring_b.domain.member.enums;
+
+public enum Gender {
+    Male, Female, NONE
+}

--- a/src/main/java/com/spring_b/domain/member/enums/MemberStatus.java
+++ b/src/main/java/com/spring_b/domain/member/enums/MemberStatus.java
@@ -1,0 +1,5 @@
+package com.spring_b.domain.member.enums;
+
+public enum MemberStatus {
+    ACTIVATE, INACTIVATE
+}

--- a/src/main/java/com/spring_b/domain/member/enums/Role.java
+++ b/src/main/java/com/spring_b/domain/member/enums/Role.java
@@ -1,0 +1,6 @@
+package com.spring_b.domain.member.enums;
+
+public enum Role {
+    ADMIN,
+    USER,
+}

--- a/src/main/java/com/spring_b/domain/member/enums/SocialType.java
+++ b/src/main/java/com/spring_b/domain/member/enums/SocialType.java
@@ -1,0 +1,5 @@
+package com.spring_b.domain.member.enums;
+
+public enum SocialType {
+    KAKAO, GOOGLE, NAVER, APPLE
+}

--- a/src/main/java/com/spring_b/domain/mission/entity/Mission.java
+++ b/src/main/java/com/spring_b/domain/mission/entity/Mission.java
@@ -1,0 +1,36 @@
+package com.spring_b.domain.mission.entity;
+
+
+import com.spring_b.domain.mapping.MemberMission;
+import com.spring_b.domain.store.entity.Store;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer reward;
+
+    private LocalDate deadline;
+
+    private String missionSpec;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL)
+    private List<MemberMission> memberMissionList = new ArrayList<>();
+}

--- a/src/main/java/com/spring_b/domain/mission/enums/MissionStatus.java
+++ b/src/main/java/com/spring_b/domain/mission/enums/MissionStatus.java
@@ -1,0 +1,5 @@
+package com.spring_b.domain.mission.enums;
+
+public enum MissionStatus {
+    CHALLENGING, COMPLETE
+}

--- a/src/main/java/com/spring_b/domain/review/entity/Review.java
+++ b/src/main/java/com/spring_b/domain/review/entity/Review.java
@@ -1,0 +1,34 @@
+package com.spring_b.domain.review.entity;
+
+
+import com.spring_b.domain.common.BaseEntity;
+import com.spring_b.domain.member.entity.Member;
+import com.spring_b.domain.store.entity.Store;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private Float score;
+
+    private String body;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+}

--- a/src/main/java/com/spring_b/domain/store/entity/Region.java
+++ b/src/main/java/com/spring_b/domain/store/entity/Region.java
@@ -1,0 +1,25 @@
+package com.spring_b.domain.store.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Region {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "region", cascade = CascadeType.ALL)
+    private List<Store> store = new ArrayList<>();
+}

--- a/src/main/java/com/spring_b/domain/store/entity/Store.java
+++ b/src/main/java/com/spring_b/domain/store/entity/Store.java
@@ -1,0 +1,28 @@
+package com.spring_b.domain.store.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String address;
+
+    private Float score;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
+
+}


### PR DESCRIPTION
## 📌 작업 내용
도메인 중심으로 엔티티를 작성하였습니다.

도메인 : food, member, mission, review, store

enums : FoodCategory, Gender, MemberStatus, Role, SocialType, MissionStatus

mapping : MemberAgree, MemberMission, MemberPrefer

## 💡 과제 피드백 Suggestion
보통 도메인 중심으로 엔티티를 작성할 때 저는 domain안에 엔티티들을 두지 않고 밖에 두는 형식으로 했었는데, 
도메인 폴더 안에 도메인 엔티티들을 작성한 이유가 궁금합니다.

## 🔗 관련 이슈
- N/A
