### PR TITLE
week9_thousandhyehyang 과제 제출

### DIFF
--- a/src/main/java/com/spring_b/thousandhyehyang/global/validation/PageValidator.java
+++ b/src/main/java/com/spring_b/thousandhyehyang/global/validation/PageValidator.java
@@ -1,0 +1,24 @@
+package com.spring_b.thousandhyehyang.global.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PageValidator implements ConstraintValidator<ValidPage, Integer> {
+
+    @Override
+    public void initialize(ValidPage constraintAnnotation) {
+        // 초기화 로직이 필요한 경우 여기에 작성
+    }
+
+    @Override
+    public boolean isValid(Integer page, ConstraintValidatorContext context) {
+        // null이면 검증 통과 (필수 여부는 @NotNull 등으로 처리)
+        if (page == null) {
+            return true;
+        }
+
+        // 페이지 번호는 1 이상이어야 함
+        return page >= 1;
+    }
+}
+

--- a/src/main/java/com/spring_b/thousandhyehyang/global/validation/ValidPage.java
+++ b/src/main/java/com/spring_b/thousandhyehyang/global/validation/ValidPage.java
@@ -1,0 +1,21 @@
+package com.spring_b.thousandhyehyang.global.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = PageValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPage {
+    String message() default "페이지 번호는 1 이상이어야 합니다";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/src/main/java/com/spring_b/thousandhyehyang/mission/controller/MissionController.java
+++ b/src/main/java/com/spring_b/thousandhyehyang/mission/controller/MissionController.java
@@ -2,7 +2,10 @@ package com.spring_b.thousandhyehyang.mission.controller;
 
 import com.spring_b.thousandhyehyang.global.apiPayload.ApiResponse;
 import com.spring_b.thousandhyehyang.global.apiPayload.code.GeneralSuccessCode;
+import com.spring_b.thousandhyehyang.mission.dto.MissionPageRequest;
+import com.spring_b.thousandhyehyang.mission.dto.MissionPageResponse;
 import com.spring_b.thousandhyehyang.mission.dto.UserMissionChallengeRequest;
+import com.spring_b.thousandhyehyang.mission.dto.UserMissionPageResponse;
 import com.spring_b.thousandhyehyang.mission.dto.UserMissionResponse;
 import com.spring_b.thousandhyehyang.mission.service.MissionService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,8 +17,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +34,63 @@ import org.springframework.web.bind.annotation.RestController;
 public class MissionController {
 
     private final MissionService missionService;
+
+    @Operation(summary = "특정 가게의 미션 목록 조회", description = "특정 가게의 미션 목록을 페이징하여 조회합니다. (한 페이지에 10개씩)")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (Validation 실패)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게를 찾을 수 없음")
+    })
+    @GetMapping("/stores/{storeId}")
+    public ResponseEntity<ApiResponse<MissionPageResponse>> getMissionsByStoreId(
+            @Parameter(description = "가게 ID", required = true, example = "1")
+            @PathVariable Long storeId,
+            @Valid @ModelAttribute MissionPageRequest request) {
+
+        MissionPageResponse response = missionService.getMissionsByStoreId(storeId, request.getPage(), request.getSize());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));
+    }
+
+    @Operation(summary = "내가 진행중인 미션 목록 조회", description = "특정 사용자가 진행중인 미션 목록을 페이징하여 조회합니다. (한 페이지에 10개씩)")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (Validation 실패)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @GetMapping("/in-progress/{userId}")
+    public ResponseEntity<ApiResponse<UserMissionPageResponse>> getInProgressMissions(
+            @Parameter(description = "사용자 ID", required = true, example = "1")
+            @PathVariable Long userId,
+            @Valid @ModelAttribute MissionPageRequest request) {
+
+        UserMissionPageResponse response = missionService.getInProgressMissions(userId, request.getPage(), request.getSize());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));
+    }
+
+    @Operation(summary = "진행중인 미션 진행 완료로 변경", description = "진행중인 미션을 완료 상태로 변경하고, 변경된 미션 정보를 반환합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "미션 완료 처리 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "미션을 찾을 수 없음 (진행중인 미션이 아님)")
+    })
+    @PutMapping("/{missionId}/complete/{userId}")
+    public ResponseEntity<ApiResponse<UserMissionResponse>> completeMission(
+            @Parameter(description = "미션 ID", required = true, example = "1")
+            @PathVariable Long missionId,
+            @Parameter(description = "사용자 ID", required = true, example = "1")
+            @PathVariable Long userId) {
+
+        UserMissionResponse response = missionService.completeMission(userId, missionId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));
+    }
 
     @Operation(summary = "미션 도전하기", description = "가게의 미션을 도전 중인 미션에 추가합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/spring_b/thousandhyehyang/mission/dto/MissionPageRequest.java
+++ b/src/main/java/com/spring_b/thousandhyehyang/mission/dto/MissionPageRequest.java
@@ -1,9 +1,8 @@
-package com.spring_b.thousandhyehyang.review.dto;
+package com.spring_b.thousandhyehyang.mission.dto;
 
 import com.spring_b.thousandhyehyang.global.validation.ValidPage;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,14 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ReviewSearchRequest {
-
-    @Size(max = 100, message = "가게명은 100자 이하여야 합니다")
-    private String storeName;
-
-    @Min(value = 0, message = "별점 범위는 0 이상이어야 합니다")
-    @Max(value = 5, message = "별점 범위는 5 이하여야 합니다")
-    private Integer ratingRange;
+public class MissionPageRequest {
 
     @ValidPage(message = "페이지 번호는 1 이상이어야 합니다")
     @Builder.Default
@@ -30,10 +22,5 @@ public class ReviewSearchRequest {
     @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다")
     @Builder.Default
     private Integer size = 10;
-
-    // 정렬 기준 (createdAt, rating, updatedAt)
-    private String sortBy;
-
-    // 정렬 방향 (ASC, DESC)
-    private String sortDirection;
 }
+

--- a/src/main/java/com/spring_b/thousandhyehyang/mission/repository/MissionRepository.java
+++ b/src/main/java/com/spring_b/thousandhyehyang/mission/repository/MissionRepository.java
@@ -49,4 +49,25 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
             @Param("sigungu") String sigungu,
             @Param("userId") Long userId,
             Pageable pageable);
+
+    /**
+     * 특정 가게의 미션 목록 조회 (페이징 포함)
+     */
+    @Query(value = """
+        SELECT m FROM Mission m
+        INNER JOIN FETCH m.store s
+        WHERE m.store.storeId = :storeId
+        AND m.deletedAt IS NULL
+        AND s.deletedAt IS NULL
+        ORDER BY m.createdAt DESC
+        """,
+        countQuery = """
+        SELECT COUNT(m) FROM Mission m
+        WHERE m.store.storeId = :storeId
+        AND m.deletedAt IS NULL
+        AND m.store.deletedAt IS NULL
+        """)
+    Page<Mission> findByStoreId(
+            @Param("storeId") Long storeId,
+            Pageable pageable);
 }

--- a/src/main/java/com/spring_b/thousandhyehyang/mission/service/MissionService.java
+++ b/src/main/java/com/spring_b/thousandhyehyang/mission/service/MissionService.java
@@ -12,12 +12,18 @@ public interface MissionService {
 
     MissionPageResponse getAvailableMissionsByRegion(MissionSearchRequest request);
 
+    MissionPageResponse getMissionsByStoreId(Long storeId, Integer page, Integer size);
+
     UserMissionPageResponse getMyMissions(Long userId, Integer page, Integer size);
+
+    UserMissionPageResponse getInProgressMissions(Long userId, Integer page, Integer size);
 
     UserMissionPageResponse getCompletedMissions(Long userId, Integer page, Integer size);
 
     MissionResponse createMission(Long storeId, Long ownerId, MissionCreateRequest request);
 
     UserMissionResponse challengeMission(Long missionId, UserMissionChallengeRequest request);
+
+    UserMissionResponse completeMission(Long userId, Long missionId);
 }
 

--- a/src/main/java/com/spring_b/thousandhyehyang/review/controller/ReviewController.java
+++ b/src/main/java/com/spring_b/thousandhyehyang/review/controller/ReviewController.java
@@ -76,10 +76,10 @@ public class ReviewController {
                 .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));
     }
 
-    @Operation(summary = "내가 작성한 리뷰 조회", description = "특정 사용자가 작성한 리뷰를 조회합니다.")
+    @Operation(summary = "내가 작성한 리뷰 목록 조회", description = "특정 사용자가 작성한 리뷰 목록을 페이징하여 조회합니다. (한 페이지에 10개씩, 페이지 번호는 1 이상)")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (Validation 실패)")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (Validation 실패, 페이지 번호는 1 이상이어야 함)")
     })
     @GetMapping("/my/{userId}")
     public ResponseEntity<ApiResponse<Page<ReviewResponse>>> getMyReviews(

--- a/src/main/java/com/spring_b/thousandhyehyang/review/dto/ReviewResponse.java
+++ b/src/main/java/com/spring_b/thousandhyehyang/review/dto/ReviewResponse.java
@@ -26,6 +26,7 @@ public class ReviewResponse {
     private Instant updatedAt;
     private List<String> imageUrls;
     private List<Reply> replies;
+    private Reply ownerReply;
 
     @Data
     @NoArgsConstructor

--- a/src/main/java/com/spring_b/thousandhyehyang/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/spring_b/thousandhyehyang/review/service/ReviewServiceImpl.java
@@ -34,7 +34,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -80,14 +79,12 @@ public class ReviewServiceImpl implements ReviewService {
                 .build();
 
         if (request.getImageUrls() != null && !request.getImageUrls().isEmpty()) {
-            List<ReviewImage> reviewImages = new ArrayList<>();
-            for (String imageUrl : request.getImageUrls()) {
-                ReviewImage reviewImage = ReviewImage.builder()
-                        .review(review)
-                        .url(imageUrl)
-                        .build();
-                reviewImages.add(reviewImage);
-            }
+            List<ReviewImage> reviewImages = request.getImageUrls().stream()
+                    .map(imageUrl -> ReviewImage.builder()
+                            .review(review)
+                            .url(imageUrl)
+                            .build())
+                    .collect(Collectors.toList());
             review.setReviewImages(reviewImages);
         }
 
@@ -175,7 +172,8 @@ public class ReviewServiceImpl implements ReviewService {
         log.info("내가 작성한 리뷰 조회 요청 - userId: {}, request: {}", userId, request);
 
         Sort sort = createSort(request.getSortBy(), request.getSortDirection());
-        Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), sort);
+        // 프론트엔드는 1-based page를 전달하므로 0-based로 변환
+        Pageable pageable = PageRequest.of(request.getPage() - 1, request.getSize(), sort);
 
         Page<Review> reviewPage = reviewRepository.findMyReviews(
                 userId,


### PR DESCRIPTION
## 📌 작업 내용

### 1. 커스텀 Validation 어노테이션 구현
- `@ValidPage` 어노테이션 및 `PageValidator` 구현
- 페이지 번호가 1 이상인지 검증하는 로직 추가
- `GlobalExceptionHandler`에서 validation 에러 자동 처리

### 2. 미션 관련 API 3개 구현
- **특정 가게의 미션 목록 조회** (`GET /api/missions/stores/{storeId}`)
  - 페이징 처리 (한 페이지에 10개씩)
  - 최신순 정렬
- **내가 진행중인 미션 목록 조회** (`GET /api/missions/in-progress/{userId}`)
  - 페이징 처리 (한 페이지에 10개씩)
  - 진행중인 미션만 필터링
- **진행중인 미션 완료 처리** (`PUT /api/missions/{missionId}/complete/{userId}`)
  - 미션 상태를 `IN_PROGRESS`에서 `COMPLETED`로 변경
  - `completedAt` 필드 설정
  - 변경된 미션 정보 반환

### 3. 리뷰 API 개선
- 리뷰 응답에 사장님 답글 정보 추가 (`ownerReply` 필드)
- `ReviewResponse`의 `OwnerReply`를 `Reply`로 통합하여 중복 제거
- 사장님 답글은 `UserRole.OWNER`이고 `parent`가 `null`인 원댓글로 식별

### 4. 페이징 처리 개선
- 프론트엔드가 1-based page를 전달하도록 변경
- Service 레이어에서 0-based로 변환하여 처리
- `ReviewSearchRequest`, `MissionPageRequest`에 `@ValidPage` 적용

### 5. Swagger 명세 추가
- 모든 API에 `@Operation`, `@ApiResponses` 어노테이션 추가
- 요청/응답 파라미터 설명 포함

### 6. 코드 리팩토링
- `ReviewServiceImpl`의 for문을 Stream API로 변경
- Converter에서 Stream API 사용 (조건 준수)
- 빌더 패턴 일관성 유지

## 💡 과제 피드백 Suggestion

### 배운 점
1. **커스텀 Validation 어노테이션 구현**
   - `ConstraintValidator` 인터페이스를 구현하여 재사용 가능한 검증 로직 작성
   - `@Constraint(validatedBy = ...)`로 Validator 연결
   - Spring이 자동으로 validation을 실행하고 에러를 처리

2. **페이징 처리의 일관성**
   - 프론트엔드는 1-based, 백엔드는 0-based를 사용하므로 변환 로직 필요
   - 모든 페이징 API에서 일관된 방식으로 처리하도록 구현

3. **DTO 설계 개선**
   - `OwnerReply`를 별도 클래스로 만들었지만, `Reply`와 구조가 동일하여 통합
   - 중복을 줄이고 유지보수성 향상

4. **Stream API 활용**
   - Converter에서 for문 대신 Stream API 사용으로 가독성 향상
   - 함수형 프로그래밍 스타일로 코드 간결화

### 개선 가능한 점
- 페이징 변환 로직을 유틸리티 메서드로 추출하여 재사용성 향상 가능
- 미션 완료 시 포인트 지급 등의 비즈니스 로직 추가 고려

## 🔗 관련 이슈

N/A